### PR TITLE
Allowed static value to be falsey

### DIFF
--- a/lib/pluck_map/attribute.rb
+++ b/lib/pluck_map/attribute.rb
@@ -9,7 +9,7 @@ module PluckMap
       @alias = name.to_s.tr("_", " ")
       @block = options[:map]
 
-      if options[:value]
+      if options.key? :value
         @value = options[:value]
         @selects = []
       else


### PR DESCRIPTION
It would be otherwise impossible to have a static value of `false` or `0` (or similar)