### PR TITLE
Stopped filtering falsey values out of args

### DIFF
--- a/lib/pluck_map/presenter.rb
+++ b/lib/pluck_map/presenter.rb
@@ -23,7 +23,7 @@ module PluckMap
     def method_missing(attribute_name, *args, &block)
       return super if initialized?
       options = args.extract_options!
-      options[:value] = args.first if args.any?
+      options[:value] = args.first unless args.empty?
       attributes.push PluckMap::Attribute.new(attribute_name, options)
       :attribute_added
     end


### PR DESCRIPTION
Sorry for the second PR in order to make this feature work. I wasn't thinking about how an array of `[false]` would return `false` for `any?`. 🤦‍♂️ This should actually unlock falsey static values.