### PR TITLE
Supply ActiveRecord model name when defining a new presenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ One drawback to this technique is its verbosity — we repeat the attribute name
 ```ruby
   def index
     messages = Message.created_by(current_user).after(3.weeks.ago)
-    presenter = PluckMap::Presenter.new do |q|
+    presenter = PluckMap[Message].define do |q|
       q.id
       q.postedAt select: :created_at
       q.text
@@ -75,7 +75,7 @@ This DSL also makes it easy to make fields optional:
 ```diff
   def index
     messages = Message.created_by(current_user).after(3.weeks.ago)
-    presenter = PluckMap::Presenter.new do |q|
+    presenter = PluckMap[Message].define do |q|
       q.id
       q.postedAt select: :created_at
       q.text

--- a/lib/pluck_map.rb
+++ b/lib/pluck_map.rb
@@ -1,10 +1,15 @@
 require "pluck_map/version"
+require "pluck_map/model_context"
 require "pluck_map/presenter"
 require "pluck_map/null_logger"
 
 module PluckMap
   class << self
     attr_accessor :logger
+
+    def [](model)
+      PluckMap::ModelContext.new(model)
+    end
   end
 
   @logger = (Rails.logger if defined?(Rails)) || PluckMap::NullLogger.new

--- a/lib/pluck_map/attribute.rb
+++ b/lib/pluck_map/attribute.rb
@@ -1,10 +1,11 @@
 module PluckMap
   class Attribute
-    attr_reader :id, :selects, :name, :value, :block
+    attr_reader :id, :model, :selects, :name, :value, :block
     attr_accessor :indexes
 
-    def initialize(id, options={})
+    def initialize(id, model, options={})
       @id = id
+      @model = model
       @selects = Array(options.fetch(:select, id))
       @name = options.fetch(:as, id)
       @block = options[:map]

--- a/lib/pluck_map/attribute_builder.rb
+++ b/lib/pluck_map/attribute_builder.rb
@@ -4,9 +4,9 @@ require "pluck_map/attributes"
 module PluckMap
   class AttributeBuilder < BasicObject
 
-    def self.build(&block)
+    def self.build(model:, &block)
       attributes = []
-      builder = self.new(attributes)
+      builder = self.new(attributes, model)
       if block.arity == 1
         block.call(builder)
       else
@@ -15,14 +15,15 @@ module PluckMap
       Attributes.new(attributes)
     end
 
-    def initialize(attributes)
+    def initialize(attributes, model)
       @attributes = attributes
+      @model = model
     end
 
     def method_missing(attribute_name, *args)
       options = args.extract_options!
       options[:value] = args.first unless args.empty?
-      @attributes.push Attribute.new(attribute_name, options)
+      @attributes.push Attribute.new(attribute_name, @model, options)
       :attribute_added
     end
 

--- a/lib/pluck_map/model_context.rb
+++ b/lib/pluck_map/model_context.rb
@@ -1,0 +1,14 @@
+require "pluck_map/presenter"
+
+module PluckMap
+  class ModelContext
+    def initialize(model)
+      @model = model
+    end
+
+    def define(&block)
+      attributes = PluckMap::AttributeBuilder.build(model: @model, &block)
+      PluckMap::Presenter.new(@model, attributes)
+    end
+  end
+end

--- a/test/attribute_builder_test.rb
+++ b/test/attribute_builder_test.rb
@@ -3,11 +3,11 @@ require "test_helper"
 class AttributeBuilderTest < Minitest::Test
 
   should "accept either a DSL-style block (no args) or a block that accepts the Builder object" do
-    a = PluckMap::AttributeBuilder.build do
+    a = PluckMap::AttributeBuilder.build(model: Author) do
       last_name
     end
 
-    b = PluckMap::AttributeBuilder.build do |builder|
+    b = PluckMap::AttributeBuilder.build(model: Author) do |builder|
       builder.last_name
     end
 
@@ -15,7 +15,7 @@ class AttributeBuilderTest < Minitest::Test
   end
 
   should "return an array of attributes for each declaration" do
-    attributes = PluckMap::AttributeBuilder.build do
+    attributes = PluckMap::AttributeBuilder.build(model: Author) do
       first_name
       last_name
     end
@@ -24,7 +24,7 @@ class AttributeBuilderTest < Minitest::Test
   end
 
   should "take the declaration as both the column to be selected and the value's name" do
-    attributes = PluckMap::AttributeBuilder.build do
+    attributes = PluckMap::AttributeBuilder.build(model: Author) do
       last_name
     end
 
@@ -33,7 +33,7 @@ class AttributeBuilderTest < Minitest::Test
   end
 
   should "allow overriding the selected attributes with select:" do
-    attributes = PluckMap::AttributeBuilder.build do
+    attributes = PluckMap::AttributeBuilder.build(model: Author) do
       last_name select: :surname
     end
 
@@ -42,7 +42,7 @@ class AttributeBuilderTest < Minitest::Test
   end
 
   should "allow overriding the value's name with as:" do
-    attributes = PluckMap::AttributeBuilder.build do
+    attributes = PluckMap::AttributeBuilder.build(model: Author) do
       last_name as: :lastName
     end
 
@@ -51,7 +51,7 @@ class AttributeBuilderTest < Minitest::Test
   end
 
   should "allow select: to be specified as an array" do
-    attributes = PluckMap::AttributeBuilder.build do
+    attributes = PluckMap::AttributeBuilder.build(model: Author) do
       last_name select: %i{ surname }
     end
 
@@ -61,7 +61,7 @@ class AttributeBuilderTest < Minitest::Test
 
   should "prohibit an empty array for :select" do
     assert_raises ArgumentError do
-      PluckMap::AttributeBuilder.build do
+      PluckMap::AttributeBuilder.build(model: Author) do
         name select: []
       end
     end
@@ -69,14 +69,14 @@ class AttributeBuilderTest < Minitest::Test
 
   should "prohibit multiple selects for :select" do
     assert_raises ArgumentError do
-      PluckMap::AttributeBuilder.build do
+      PluckMap::AttributeBuilder.build(model: Author) do
         name select: %i{ first_name last_name }
       end
     end
   end
 
   should "coerce selects to an empty array of selects when value: is given" do
-    attributes = PluckMap::AttributeBuilder.build do
+    attributes = PluckMap::AttributeBuilder.build(model: Author) do
       type value: "Author", selects: %i{ a b c }
     end
 
@@ -85,7 +85,7 @@ class AttributeBuilderTest < Minitest::Test
   end
 
   should "allow value: to be falsey" do
-    attributes = PluckMap::AttributeBuilder.build do
+    attributes = PluckMap::AttributeBuilder.build(model: Author) do
       living value: false
     end
 
@@ -93,7 +93,7 @@ class AttributeBuilderTest < Minitest::Test
   end
 
   should "allow multiple selects when map: is given" do
-    attributes = PluckMap::AttributeBuilder.build do
+    attributes = PluckMap::AttributeBuilder.build(model: Author) do
       name select: %i{ first_name last_name }, map: ->(first, last) { "#{first} #{last}" }
     end
 

--- a/test/backwards_compatibility_test.rb
+++ b/test/backwards_compatibility_test.rb
@@ -17,9 +17,11 @@ class BackwardsCompatibilityTest < Minitest::Test
 
       mock.instance_of(klass).define_for_json_api!
 
-      klass.new do
+      presenter = klass.new do
         last_name
       end
+
+      presenter.to_h(Author.all)
     end
   end
 

--- a/test/benchmarks.rb
+++ b/test/benchmarks.rb
@@ -16,7 +16,7 @@ ActiveRecord::Base.establish_connection(
 load File.join(File.dirname(__FILE__), "support", "schema.rb")
 
 def define_benchmarks!(x)
-  presenter = PluckMap::Presenter.new do
+  presenter = PluckMap[Author].define do
     id
     first_name
     last_name

--- a/test/csv_presenter_test.rb
+++ b/test/csv_presenter_test.rb
@@ -19,7 +19,7 @@ class CsvPresenterTest < Minitest::Test
 
   context "#to_csv" do
     should "pluck the identified fields for a model from the database" do
-      presenter = PluckMap::Presenter.new do
+      presenter = PluckMap[Author].define do
         first_name as: "Name, First"
         last_name as: "Name, Last"
       end

--- a/test/json_presenter_test.rb
+++ b/test/json_presenter_test.rb
@@ -18,7 +18,7 @@ class JsonPresenterTest < Minitest::Test
 
 
   should "pluck the identified fields for a model from the database" do
-    presenter = PluckMap::Presenter.new do
+    presenter = PluckMap[Author].define do
       last_name
     end
 

--- a/test/pluck_map_test.rb
+++ b/test/pluck_map_test.rb
@@ -18,7 +18,7 @@ class PluckMapTest < Minitest::Test
 
 
   should "pluck the identified fields for a model from the database" do
-    presenter = PluckMap::Presenter.new do
+    presenter = PluckMap[Author].define do
       last_name
     end
 
@@ -31,7 +31,7 @@ class PluckMapTest < Minitest::Test
   should "pluck attributes from the relation's table when joins make them ambiguous" do
     Book.create!(title: "The Chosen", author: authors.second)
 
-    presenter = PluckMap::Presenter.new do
+    presenter = PluckMap[Author].define do
       id
     end
 
@@ -42,7 +42,7 @@ class PluckMapTest < Minitest::Test
 
   context "when :value is given" do
     should "present the value statically for each result" do
-      presenter = PluckMap::Presenter.new do
+      presenter = PluckMap[Author].define do
         type value: "Author"
         last_name
       end
@@ -56,7 +56,7 @@ class PluckMapTest < Minitest::Test
 
   context "when :as is given" do
     should "present the plucked value with the specified key" do
-      presenter = PluckMap::Presenter.new do
+      presenter = PluckMap[Author].define do
         last_name as: :lastName
       end
 
@@ -68,7 +68,7 @@ class PluckMapTest < Minitest::Test
 
     context "and it contains spaces" do
       should "still work" do
-        presenter = PluckMap::Presenter.new do
+        presenter = PluckMap[Author].define do
           last_name as: "Last Name"
         end
 
@@ -88,7 +88,7 @@ class PluckMapTest < Minitest::Test
         Arel.sql("first_name || ' ' || last_name")
       end
 
-      presenter = PluckMap::Presenter.new do
+      presenter = PluckMap[Author].define do
         name select: concat_sql
       end
 
@@ -101,7 +101,7 @@ class PluckMapTest < Minitest::Test
 
   context "when :map is given" do
     should "yields the selected values to map" do
-      presenter = PluckMap::Presenter.new do
+      presenter = PluckMap[Author].define do
         name select: %i{ first_name last_name }, map: ->(first, last) { "#{first} #{last}" }
       end
 
@@ -114,7 +114,7 @@ class PluckMapTest < Minitest::Test
 
   context "when a value is selected more than once" do
     should "associate the right values with the right attributes" do
-      presenter = PluckMap::Presenter.new do
+      presenter = PluckMap[Author].define do
         first select: :first_name
         last select: :last_name
         full select: %i{ first_name last_name }, map: ->(first, last) { "#{first} #{last}" }


### PR DESCRIPTION
#### Before

```ruby
presenter = PluckMap::Presenter.new do |q|
  # ...
end
presenter.to_h(messages)
```

#### After

```ruby
presenter = PluckMap[Message].define do |q|
  # ...
end
presenter.to_h(messages)
```

## Rationale

This makes `klass.arel_table` and the ability to reflect on the model's associations available at "compile time" for PluckMap presenters rather than only at run time. This paves the way for a DSL supporting nested relationships and for optimizations as well.