### PR TITLE
Restored alias to single, non-symbol attribute selects

### DIFF
--- a/lib/pluck_map/presenter.rb
+++ b/lib/pluck_map/presenter.rb
@@ -55,7 +55,11 @@ module PluckMap
     end
 
     def selects
-      attributes.selects
+      attributes.selects.map.with_index { |select, index|
+        select = select.is_a?(Symbol) ? select : select.as("pluck_select_#{index}")
+        select = Arel.sql(select.to_sql) if ActiveRecord.version.segments.take(2) == [4,2] && select.respond_to?(:to_sql)
+        select
+      }
     end
 
     def attributes_by_id

--- a/test/pluck_map_test.rb
+++ b/test/pluck_map_test.rb
@@ -97,6 +97,18 @@ class PluckMapTest < Minitest::Test
         { name: "Chiam Potok" }
       ], presenter.to_h(authors)
     end
+
+    should "correctly cast types when using the same SQL function multiple times" do
+      presenter = PluckMap[Author].define do
+        last_name select: Arel.sql("COALESCE(NULL, last_name)")
+        id select: Arel.sql("COALESCE(NULL, id)")
+      end
+
+      assert_equal [
+        { last_name: "Greene", id: authors.find_by(last_name: "Greene").id },
+        { last_name: "Potok", id: authors.find_by(last_name: "Potok").id }
+      ], presenter.to_h(authors)
+    end
   end
 
   context "when :map is given" do


### PR DESCRIPTION
This was a tricky bug to track down, but [this commit](a399ead610633c0449d80165f10a222dfd39baca) introduces a subtle regression that actually seems related to some [odd behavior](https://github.com/rails/rails/issues/36042) in Rails' type casting. From what I can gather, Rails' type casting maps results and what type they should be cast to by name; when each select's name is unique (or aliased to something unique), there's no problem. However, when two selects share a name, either by selecting the same-named column in joined tables (as in the linked issue) OR by calling the same SQL function (I ran into it by plucking `COALESCE()` functions), Rails will cast _all_ of them to the type of the _last_ one. This leads to unexpected results when, say, one `COALESCE` results in an array and another in a string. What you expected to be an array will instead show up as `"{value1,value2,value3}"` ... or more confoundingly `nil` instead of `[]`! 😱

This commit reverts the removal of built-in aliasing to mitigate the issue.