### PR TITLE
Pass type to relationships block for polymorphic belongs_to relationships

### DIFF
--- a/lib/pluck_map/relationships/polymorphic_one.rb
+++ b/lib/pluck_map/relationships/polymorphic_one.rb
@@ -39,6 +39,8 @@ module PluckMap
 
             if @attributes_block.arity == 1
               @attributes_block.call(q)
+            elsif @attributes_block.arity == 2
+              @attributes_block.call(q, type)
             else
               q.instance_eval(&@attributes_block)
             end


### PR DESCRIPTION
When plucking for JSON:API, one can pass information about a record's relationships by passing related ids and types. Using pluck_map relationships, you can easily set the type for normal `belongs_to` and `has_many` relationships by simply setting a value in the block. But for polymorphic `belongs_to` relationships, you need to be able to pull the type information from the database. Rails has that information on the record, in the `relationship_type` field. However, when trying to pluck using relationships, by the time we're building the related record, we don't have access to that field from the parent record; we only have the information available on the associated tables, from which it's difficult to discern type information. So, for example:

```ruby
class Book < ActiveRecord::Base
  belongs_to :owner, polymorphic: true
end

class Library
  has_many :books, as: :owner
end

class Person
  has_many :books, as: :owner
end
```

If you wanted to present information about a book's owner in JSON:API format, you'd need to build a presenter along the lines of:

```ruby
PluckMap[Book].define do
  id
  has_one :owner do
    id
    type # <-- How do we get this?
  end
end
```

By the time the `Relationships::PolymorphicOne` is plucking libraries and people, the relationship block doesn't know about the `owner_type` on `books`, which would provide it with exactly the information it needs to supply `type`.

My goal in addressing this was to keep the relationships API as straightforward as it currently is -- it seemed clunky to add more options to `has_one` and more conditionals and types potentially to handle them. As such, the solution I came up with was merely to pass the `type` that `Relationships::PolymorphicOne` has already plucked out to facilitate preloading related records in as an additional argument to the block, if it will accept it. So then the above presenter becomes:

```ruby
PluckMap[Book].define do
  id
  has_one :owner do |q, type|
    q.id
    q.type type
  end
end
```

This would make it so that you're required to use the query argument syntax in order to have access to type information. I don't love that, but the solution is only for unlocking this particular use case, and it keeps this from being a breaking change for any that might've already adopted 1.0.0 syntax.

I'd be curious to hear your thoughts on this. 🙂