### PR TITLE
Added structured attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* FEATURE: Add structured attributes to allow nesting attributes as a hash (@kobsy)
+
 ## v1.0.0.rc1 (2019 May 12)
 
 * BREAKING: Remove deprecated features/methods (@boblail)

--- a/README.md
+++ b/README.md
@@ -208,6 +208,19 @@ presenter = PluckMap[Person].define do
 end
 ```
 
+### Structured attributes
+
+You can also nest attributes by passing a block to the attribute method:
+
+```ruby
+presenter = PluckMap[Person].define do
+  parent do
+    id select: :parent_id
+    type "Parent"
+  end
+end
+```
+
 ### Relationships
 
 PluckMap can also describe nested data. There are two special methods in the `define` block that introduce child resources:

--- a/lib/pluck_map/attribute_builder.rb
+++ b/lib/pluck_map/attribute_builder.rb
@@ -1,4 +1,5 @@
 require "pluck_map/attribute"
+require "pluck_map/structured_attribute"
 require "pluck_map/attributes"
 require "pluck_map/relationships"
 
@@ -21,10 +22,11 @@ module PluckMap
       @model = model
     end
 
-    def method_missing(attribute_name, *args)
+    def method_missing(attribute_name, *args, &block)
       options = args.extract_options!
       options[:value] = args.first unless args.empty?
-      @attributes.push Attribute.new(attribute_name, @model, options)
+      @attributes.push block.nil? ? Attribute.new(attribute_name, @model, options) :
+        StructuredAttribute.new(attribute_name, @model, block, options)
       :attribute_added
     end
 

--- a/lib/pluck_map/presenters/to_json.rb
+++ b/lib/pluck_map/presenters/to_json.rb
@@ -51,6 +51,10 @@ module PluckMap
       arg
     end
 
+    def prepare_PluckMap_StructuredAttribute(attribute)
+      to_json_object(attribute.attributes)
+    end
+
     def prepare_PluckMap_Relationships_Many(attribute)
       PluckMap::JsonSubqueryAggregate.new(attribute.scope, to_json_object(attribute.attributes))
     end

--- a/lib/pluck_map/relationships/base.rb
+++ b/lib/pluck_map/relationships/base.rb
@@ -1,27 +1,14 @@
-require "pluck_map/attribute"
+require "pluck_map/structured_attribute"
 
 module PluckMap
   module Relationships
-    class Base < Attribute
-      attr_reader :attributes, :scope
+    class Base < StructuredAttribute
+      attr_reader :scope
 
       def initialize(attribute_name, scope, block, options)
         @scope = scope
-        @attributes = AttributeBuilder.build(model: scope.klass, &block)
         @scope = @scope.instance_exec(&options[:scope_block]) if options[:scope_block]
-        options = options.slice(:as).merge(
-          select: build_select,
-          map: build_map)
-
-        super(attribute_name, scope.klass, options)
-      end
-
-      def will_map?
-        attributes.any?(&:will_map?)
-      end
-
-      def nested?
-        true
+        super(attribute_name, scope.klass, block, options)
       end
 
     protected

--- a/lib/pluck_map/structured_attribute.rb
+++ b/lib/pluck_map/structured_attribute.rb
@@ -1,0 +1,37 @@
+require "pluck_map/attribute"
+
+module PluckMap
+  class StructuredAttribute < Attribute
+    attr_reader :attributes
+
+    def initialize(attribute_name, model, block, options={})
+      @attributes = AttributeBuilder.build(model: model, &block)
+      options = options.slice(:as).merge(select: build_select, map: build_map)
+      super(attribute_name, model, options)
+    end
+
+    def will_map?
+      attributes.any?(&:will_map?)
+    end
+
+    def nested?
+      true
+    end
+
+  protected
+
+    def build_select
+      attributes.selects
+    end
+
+    def build_map
+      lambda do |*values|
+        return nil if values.none?
+        attributes.each_with_object({}) do |attribute, hash|
+          hash[attribute.name] = attribute.exec(values)
+        end
+      end
+    end
+
+  end
+end

--- a/test/attribute_builder_test.rb
+++ b/test/attribute_builder_test.rb
@@ -115,4 +115,16 @@ class AttributeBuilderTest < Minitest::Test
     assert_equal %i{ first_name last_name }, attributes[0].selects
   end
 
+  should "allow structured attributes" do
+    attributes = PluckMap::AttributeBuilder.build(model: Book) do
+      author do
+        id select: :author_id
+        type select: :author_type
+      end
+    end
+
+    assert_equal :author, attributes[0].name
+    assert_equal %i{ author_id author_type }, attributes[0].attributes.selects
+  end
+
 end

--- a/test/csv_presenter_test.rb
+++ b/test/csv_presenter_test.rb
@@ -31,16 +31,17 @@ class CsvPresenterTest < Minitest::Test
       TEXT
     end
 
-    should "raise an error if the presenter uses relationships" do
-      presenter = PluckMap[Person].define do
-        last_name
-        has_many :books do
-          title
+    should "raise an error if the presenter uses structured attributes" do
+      presenter = PluckMap[Book].define do
+        title
+        author do
+          id select: :author_id
+          type select: :author_type
         end
       end
 
       assert_raises PluckMap::UnsupportedAttributeError do
-        presenter.to_csv(authors)
+        presenter.to_csv(Book.all)
       end
     end
   end

--- a/test/json_presenter_test.rb
+++ b/test/json_presenter_test.rb
@@ -11,12 +11,12 @@ class JsonPresenterTest < Minitest::Test
     ])
     @authors = Person.order(:last_name)
 
-    greene, potok = authors.pluck(:id)
+    @greene, @potok = authors.pluck(:id)
     Book.create!([
-      { author_id: greene, author_type: "Person", title: "The Tenth Man" },
-      { author_id: greene, author_type: "Person", title: "The Power and the Glory" },
-      { author_id: potok, author_type: "Person", title: "The Chosen" },
-      { author_id: potok, author_type: "Person", title: "My Name is Asher Lev" }
+      { author_id: @greene, author_type: "Person", title: "The Tenth Man" },
+      { author_id: @greene, author_type: "Person", title: "The Power and the Glory" },
+      { author_id: @potok, author_type: "Person", title: "The Chosen" },
+      { author_id: @potok, author_type: "Person", title: "My Name is Asher Lev" }
     ])
     @books = Book.order(title: :desc)
   end
@@ -132,6 +132,29 @@ class JsonPresenterTest < Minitest::Test
             { "title": "The Power and the Glory", "isbn": { "number": "978-9994715640" } },
             { "title": "The Chosen", "isbn": null },
             { "title": "My Name is Asher Lev", "isbn": null }
+          ]
+          JSON
+        end
+      end
+
+      context "with structured attributes:" do
+        setup do
+          @presenter = PluckMap[Book].define do
+            title
+            author do
+              id select: :author_id
+              type select: :author_type
+            end
+          end
+        end
+
+        should "present the requested fields" do
+          assert_json_equal <<~JSON, presenter.send(method, books)
+          [
+            { "title": "The Tenth Man", "author": { "id": #{@greene}, "type": "Person" } },
+            { "title": "The Power and the Glory", "author": { "id": #{@greene}, "type": "Person" } },
+            { "title": "The Chosen", "author": { "id": #{@potok}, "type": "Person" } },
+            { "title": "My Name is Asher Lev", "author": { "id": #{@potok}, "type": "Person" } }
           ]
           JSON
         end

--- a/test/pluck_map_test.rb
+++ b/test/pluck_map_test.rb
@@ -154,4 +154,28 @@ class PluckMapTest < Minitest::Test
     end
   end
 
+  context "when presenting a structured attribute" do
+    should "present the attribute as nested" do
+      greene = authors.first
+      potok = authors.last
+      Book.create!([
+        { title: "The Tenth Man", author_id: greene.id, author_type: "Person" },
+        { title: "The Chosen", author_id: potok.id, author_type: "Person" }
+      ])
+
+      presenter = PluckMap[Book].define do
+        title
+        author do
+          id select: :author_id
+          type select: :author_type
+        end
+      end
+
+      assert_equal [
+        { title: "The Chosen", author: { id: potok.id, type: "Person" } },
+        { title: "The Tenth Man", author: { id: greene.id, type: "Person" } }
+      ], presenter.to_h(Book.order(:title))
+    end
+  end
+
 end


### PR DESCRIPTION
After chatting with you about this earlier today, I thought I'd take a crack at implementing it. 😁

This should allow for structuring attributes where all the information is already on the record, e.g., a polymorphic `belongs_to` where all you need are the foreign key and the type (as in a JSON:API relationship object). Besides being more elegant than passing an extra attribute to the attribute builder block (but only _sometimes_), it should have broader applicability beyond the narrow use case of presenting for JSON:API.