### PR TITLE
Structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* BREAKING: `define` returns a subclass of `PluckMap::Presenter` instead of an instance (@boblail)
+
 ## v1.0.0 (2019 Jul 17)
 
 * FIX: Respect default_scopes for relationships (@boblail)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * BREAKING: `define` returns a subclass of `PluckMap::Presenter` instead of an instance (@boblail)
+* FEATURE: `define` also creates structs to correspond to each presenter (@boblail)
 
 ## v1.0.0 (2019 Jul 17)
 

--- a/lib/pluck_map/attributes.rb
+++ b/lib/pluck_map/attributes.rb
@@ -37,6 +37,10 @@ module PluckMap
 
 
 
+    def ids
+      _attributes_by_id.keys
+    end
+
     def by_id
       _attributes_by_id
     end

--- a/lib/pluck_map/model_context.rb
+++ b/lib/pluck_map/model_context.rb
@@ -8,7 +8,21 @@ module PluckMap
 
     def define(&block)
       attributes = PluckMap::AttributeBuilder.build(model: @model, &block)
-      PluckMap::Presenter.new(@model, attributes)
+      define_class!(@model, attributes)
+    end
+
+  private
+
+    def define_class!(model, attributes)
+      # Create a new subclass of PluckMap::Presenter
+      klass = Class.new(PluckMap::Presenter)
+
+      # Partially apply initialize with the parameters passed to this method
+      klass.define_method(:initialize) do |query|
+        super(model, attributes, query)
+      end
+
+      klass
     end
   end
 end

--- a/lib/pluck_map/model_context.rb
+++ b/lib/pluck_map/model_context.rb
@@ -1,4 +1,5 @@
 require "pluck_map/presenter"
+require "pluck_map/struct"
 
 module PluckMap
   class ModelContext
@@ -21,6 +22,12 @@ module PluckMap
       klass.define_method(:initialize) do |query|
         super(model, attributes, query)
       end
+
+      # Generate a Struct constant in the namespace of the new subclass
+      struct = ::Struct.new(*attributes.ids, keyword_init: true)
+      struct.extend PluckMap::Struct::ClassMethods
+      struct.instance_variable_set :@presenter, klass
+      klass.const_set :Struct, struct
 
       klass
     end

--- a/lib/pluck_map/presenter.rb
+++ b/lib/pluck_map/presenter.rb
@@ -9,20 +9,21 @@ module PluckMap
   class Presenter
     include CsvPresenter, HashPresenter, JsonPresenter
 
-    attr_reader :model, :attributes
+    attr_reader :model, :attributes, :query
 
-    def initialize(model, attributes)
-      @model = model
-      @attributes = attributes
-    end
-
-  protected
-
-    def pluck(query)
+    def initialize(model, attributes, query)
       unless query.model <= model
         raise ArgumentError, "Query for #{query.model} but #{model} expected"
       end
 
+      @model = model
+      @attributes = attributes
+      @query = query
+    end
+
+  protected
+
+    def pluck
       # puts "\e[95m#{query.select(*selects).to_sql}\e[0m"
       results = benchmark("pluck(#{query.table_name})") { query.pluck(*selects) }
       return results unless block_given?
@@ -70,6 +71,7 @@ module PluckMap
 
         # On Rails 4.2, `pluck` can't accept Arel nodes
         select = Arel.sql(select.to_sql) if ActiveRecord.version.segments.take(2) == [4,2] && select.respond_to?(:to_sql)
+
         select
       }
     end

--- a/lib/pluck_map/presenters/to_csv.rb
+++ b/lib/pluck_map/presenters/to_csv.rb
@@ -3,13 +3,19 @@ require "pluck_map/errors"
 module PluckMap
   module CsvPresenter
 
-    def to_csv(query)
+    def self.included(base)
+      def base.to_csv(query, **kargs)
+        new(query).to_csv(**kargs)
+      end
+    end
+
+    def to_csv
       if attributes.nested?
         raise PluckMap::UnsupportedAttributeError, "to_csv can not be used to present nested attributes"
       end
 
       define_to_csv!
-      to_csv(query)
+      to_csv
     end
 
     private def define_to_csv!
@@ -17,8 +23,8 @@ module PluckMap
 
       headers = CSV.generate_line(attributes.map(&:name))
       ruby = <<-RUBY
-      def to_csv(query)
-        pluck(query) do |results|
+      def to_csv
+        pluck do |results|
           rows = [#{headers.inspect}]
           results.each_with_object(rows) do |values, rows|
             values = Array(values)

--- a/lib/pluck_map/presenters/to_h.rb
+++ b/lib/pluck_map/presenters/to_h.rb
@@ -1,15 +1,21 @@
 module PluckMap
   module HashPresenter
 
-    def to_h(query)
+    def self.included(base)
+      def base.to_h(query, **kargs)
+        new(query).to_h(**kargs)
+      end
+    end
+
+    def to_h
       define_to_h!
-      to_h(query)
+      to_h
     end
 
     private def define_to_h!
       ruby = <<-RUBY
-      def to_h(query)
-        pluck(query) do |results|
+      def to_h
+        pluck do |results|
           results.map { |values| values = Array(values); { #{attributes.map { |attribute| "#{attribute.name.inspect} => #{attribute.to_ruby}" }.join(", ")} } }
         end
       end

--- a/lib/pluck_map/struct.rb
+++ b/lib/pluck_map/struct.rb
@@ -1,0 +1,13 @@
+module PluckMap
+  module Struct
+    module ClassMethods
+      def presenter
+        @presenter || superclass.presenter
+      end
+
+      def load(relation)
+        presenter.to_h(relation).map { |values| new(**values) }
+      end
+    end
+  end
+end

--- a/pluck_map.gemspec
+++ b/pluck_map.gemspec
@@ -17,6 +17,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  # uses `keyword_init` argument of `Struct.new`
+  spec.required_ruby_version = '>= 2.5.0'
+
   spec.add_dependency "activerecord", ">= 4.2"
 
   spec.add_development_dependency "appraisal"

--- a/test/benchmarks.rb
+++ b/test/benchmarks.rb
@@ -68,7 +68,7 @@ def define_benchmarks!(x)
   end
 
   x.report("PluckMap") do
-    presenter.send(:to_json__default, Person.order(:last_name))
+    presenter.new(Person.order(:last_name)).send(:to_json__default)
   end
 
   x.report("Pluck Json") do
@@ -76,7 +76,7 @@ def define_benchmarks!(x)
   end
 
   x.report("to_json__optimized") do
-    presenter.send(:to_json__optimized, Person.order(:last_name))
+    presenter.new(Person.order(:last_name)).send(:to_json__optimized)
   end
 end
 

--- a/test/json_presenter_test.rb
+++ b/test/json_presenter_test.rb
@@ -48,7 +48,7 @@ class JsonPresenterTest < Minitest::Test
           last_name
         end
 
-        assert_json_equal <<~JSON, presenter.send(method, authors)
+        assert_json_equal <<~JSON, presenter.new(authors).send(method)
         [
           { "last_name": "Greene" },
           { "last_name": "Potok" }
@@ -70,7 +70,7 @@ class JsonPresenterTest < Minitest::Test
         end
 
         should "present the requested fields" do
-          assert_json_equal <<~JSON, presenter.send(method, authors)
+          assert_json_equal <<~JSON, presenter.new(authors).send(method)
           [
             { "last_name": "Greene",
               "books": [
@@ -100,7 +100,7 @@ class JsonPresenterTest < Minitest::Test
         end
 
         should "present the requested fields" do
-          assert_json_equal <<~JSON, presenter.send(method, books)
+          assert_json_equal <<~JSON, presenter.new(books).send(method)
           [
             { "author": { "name": "Graham Greene" }, "title": "The Tenth Man" },
             { "author": { "name": "Graham Greene" }, "title": "The Power and the Glory" },
@@ -126,7 +126,7 @@ class JsonPresenterTest < Minitest::Test
         end
 
         should "yield the selected values to map" do
-          assert_json_equal <<~JSON, presenter.send(method, books)
+          assert_json_equal <<~JSON, presenter.new(books).send(method)
           [
             { "title": "The Tenth Man", "isbn": { "number": "978-0671507947" } },
             { "title": "The Power and the Glory", "isbn": { "number": "978-9994715640" } },
@@ -149,7 +149,7 @@ class JsonPresenterTest < Minitest::Test
         end
 
         should "present the requested fields" do
-          assert_json_equal <<~JSON, presenter.send(method, books)
+          assert_json_equal <<~JSON, presenter.new(books).send(method)
           [
             { "title": "The Tenth Man", "author": { "id": #{@greene}, "type": "Person" } },
             { "title": "The Power and the Glory", "author": { "id": #{@greene}, "type": "Person" } },

--- a/test/struct_test.rb
+++ b/test/struct_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+class StructTest < Minitest::Test
+  attr_reader :authors
+
+  def setup
+    DatabaseCleaner.start
+    Person.create!([
+      { first_name: "Graham", last_name: "Greene" },
+      { first_name: "Chiam", last_name: "Potok" }
+    ])
+    @authors = Person.order(:last_name)
+  end
+
+  def teardown
+    DatabaseCleaner.clean
+  end
+
+  context "presenter::Struct" do
+    setup do
+      @presenter = PluckMap[Person].define do
+        first_name
+        last_name
+      end
+    end
+
+    should "be a struct" do
+      assert @presenter::Struct.ancestors.include?(Struct)
+    end
+
+    should "differ from another presenter's struct" do
+      another = PluckMap[Book].define do
+        title
+      end
+
+      refute_equal @presenter::Struct.members, another::Struct.members
+      refute_equal @presenter::Struct.presenter, another::Struct.presenter
+    end
+
+    context ".members" do
+      should "correspond to the values being plucked" do
+        assert_equal %i{ first_name last_name }, @presenter::Struct.members
+      end
+    end
+
+    context ".load" do
+      should "pluck the results to instances of presenter::Struct" do
+        assert_equal [
+          @presenter::Struct.new(first_name: "Graham", last_name: "Greene"),
+          @presenter::Struct.new(first_name: "Chiam", last_name: "Potok")
+        ], @presenter::Struct.load(authors)
+      end
+
+      should "pluck the results to instances of subclasses of presenter::Struct" do
+        subclass = Class.new(@presenter::Struct)
+
+        assert_equal [
+          subclass.new(first_name: "Graham", last_name: "Greene"),
+          subclass.new(first_name: "Chiam", last_name: "Potok")
+        ], subclass.load(authors)
+      end
+
+      should "pluck the results to instances of grandchildren of presenter::Struct" do
+        subclass = Class.new(@presenter::Struct)
+        grandchild = Class.new(subclass)
+
+        assert_equal [
+          grandchild.new(first_name: "Graham", last_name: "Greene"),
+          grandchild.new(first_name: "Chiam", last_name: "Potok")
+        ], grandchild.load(authors)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
### Description

**`PluckMap[Book].define` returns a subclass of `PluckMap::Presenter` instead of an instance of it.**

I think the only thing about PluckMap's API that this would change is how you mix in new presenter methods (instance methods don't accept `query`; you need to define class methods that do).

Classes returned by `define` have class methods for `to_json`, `to_csv`, etc, so _using_ `PluckMap` shouldn't change at all.

The change from instance to class allows for a few things:

1. It encourages you to write

    ```ruby
    BookPresenter = PluckMap[Book].define do
      title
    end
    ```

    instead of


    ```ruby
    presenter = PluckMap[Book].define do
      title
    end
    ```

    although both still work.

    I prefer this because it encourages you to assign the result of `define` once rather than to redefine presenters at runtime in all the places where they're used.

2. It allows you to subclass (or extend) specific presenters.

3. It allows calls to (e.g.) `to_json` to be implict. For example:

    ```ruby
    def index
      render json: BookPresenter.new(current_user.books)
    end
    ```

4. It allows PluckMap to define objects namespaced to the presenters it defines. For example:

    ```ruby
    BookPresenter = PluckMap[Book].define do
      id
      title
    end

    BookPresenter::Struct.members
    # => [:id, :title]

    BookPresenter::Struct.load(Book.all)
    # => [#<struct BookPresenter::Struct title="The Chosen">]

    # This is now truly a view model
    class BookEnumValue < BookPresenter::Struct
      include ActionView::Helpers::SanitizeHelper

      def title
        sanitize super
      end
    end

    BookEnumValue.load(Book.all)
    # => [#<struct BookEnumValue title="The Chosen">]
    ```
