### PR TITLE
Made necessary changes to allow use with Rails 7.0+

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,30 +1,26 @@
-appraise "rails-4.2" do
-  gem "activerecord", "~> 4.2.0"
-  gem "sqlite3", "~> 1.3.6"
-  gem "pg", "~> 0.20"
-end
-
-appraise "rails-5.0" do
-  gem "activerecord", "~> 5.0.0"
-  gem "sqlite3", "~> 1.3.6"
-end
-
-appraise "rails-5.1" do
-  gem "activerecord", "~> 5.1.0"
-  gem "sqlite3", "~> 1.3.6"
-end
-
-appraise "rails-5.2" do
-  gem "activerecord", "~> 5.2.0"
-  gem "sqlite3", "~> 1.3.6"
-end
-
 appraise "rails-6.0" do
   gem "activerecord", "~> 6.0.0"
-  gem "sqlite3", "~> 1.4.0"
+  gem 'concurrent-ruby', '1.3.4'
+  gem "sqlite3"
 end
 
-appraise "rails-edge" do
-  gem "rails", git: "https://github.com/rails/rails.git", branch: "master", require: "activerecord"
-  gem "sqlite3", "~> 1.4.0"
+appraise "rails-7.0" do
+  gem "rails", "~> 7.0.0"
+  gem 'concurrent-ruby', '1.3.4'
+  gem "sqlite3"
+end
+
+appraise "rails-7.1" do
+  gem "rails", "~> 7.1.0"
+  gem "sqlite3"
+end
+
+appraise "rails-7.2" do
+  gem "rails", "~> 7.2.0"
+  gem "sqlite3"
+end
+
+appraise "rails-8.0" do
+  gem "rails", "~> 8.0.0"
+  gem "sqlite3"
 end

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 6.0.0"
-gem "sqlite3", "~> 1.4.0"
+gem "concurrent-ruby", "1.3.4"
+gem "sqlite3"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 4.2.0"
-gem "sqlite3", "~> 1.3.6"
-gem "pg", "~> 0.20"
+gem "rails", "~> 7.0.0"
+gem "concurrent-ruby", "1.3.4"
+gem "sqlite3"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.0.0"
-gem "sqlite3", "~> 1.3.6"
+gem "rails", "~> 7.1.0"
+gem "sqlite3"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.2.0"
-gem "sqlite3", "~> 1.3.6"
+gem "rails", "~> 7.2.0"
+gem "sqlite3"
 
 gemspec path: "../"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.1.0"
-gem "sqlite3", "~> 1.3.6"
+gem "rails", "~> 8.0.0"
+gem "sqlite3"
 
 gemspec path: "../"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", git: "https://github.com/rails/rails.git", branch: "master", require: "activerecord"
-gem "sqlite3", "~> 1.4.0"
+gem "rails", git: "https://github.com/rails/rails.git", branch: "main", require: "activerecord"
+gem "sqlite3"
 
 gemspec path: "../"

--- a/lib/pluck_map/presenter.rb
+++ b/lib/pluck_map/presenter.rb
@@ -4,6 +4,7 @@ require "pluck_map/nodes"
 require "pluck_map/presenters"
 require "pluck_map/visitors"
 require "active_record"
+require "benchmark"
 
 module PluckMap
   class Presenter
@@ -35,8 +36,8 @@ module PluckMap
 
     def benchmark(title)
       result = nil
-      ms = Benchmark.ms { result = yield }
-      PluckMap.logger.info "\e[33m#{title}: \e[1m%.1fms\e[0m" % ms
+      ms = Benchmark.realtime { result = yield }
+      PluckMap.logger.info "\e[33m#{title}: \e[1m%.1fms\e[0m" % (ms * 1000)
       result
     end
 

--- a/lib/pluck_map/presenters/to_csv.rb
+++ b/lib/pluck_map/presenters/to_csv.rb
@@ -34,7 +34,8 @@ module PluckMap
       end
       RUBY
       # puts "\e[34m#{ruby}\e[0m" # <-- helps debugging PluckMapPresenter
-      class_eval ruby, __FILE__, __LINE__ - 7
+      klass = self.is_a?(Class) ? self : self.class
+      klass.class_eval ruby, __FILE__, __LINE__ - ruby.length
     end
 
   end

--- a/lib/pluck_map/presenters/to_h.rb
+++ b/lib/pluck_map/presenters/to_h.rb
@@ -21,7 +21,8 @@ module PluckMap
       end
       RUBY
       # puts "\e[34m#{ruby}\e[0m" # <-- helps debugging PluckMapPresenter
-      class_eval ruby, __FILE__, __LINE__ - 7
+      klass = self.is_a?(Class) ? self : self.class
+      klass.class_eval ruby, __FILE__, __LINE__ - ruby.length
     end
 
   end

--- a/lib/pluck_map/presenters/to_json.rb
+++ b/lib/pluck_map/presenters/to_json.rb
@@ -38,7 +38,8 @@ module PluckMap
       end
       RUBY
       # puts "\e[34m#{ruby}\e[0m" # <-- helps debugging PluckMapPresenter
-      class_eval ruby, __FILE__, __LINE__ - ruby.length
+      klass = self.is_a?(Class) ? self : self.class
+      klass.class_eval ruby, __FILE__, __LINE__ - ruby.length
     end
 
     def to_json_object(attributes)

--- a/lib/pluck_map/relationships.rb
+++ b/lib/pluck_map/relationships.rb
@@ -42,9 +42,9 @@ module PluckMap
         #
         # ActiveRecord::Associations::AssociationScope expects the latter.
         #
-        model._reflections.fetch(name.to_s) do
+        reflections = model._reflections
+        reflections[name.to_s] || reflections[name.to_sym] or
           raise ArgumentError, "#{name} is not an association on #{model}"
-        end
       end
 
       def association_for(reflection)
@@ -81,6 +81,10 @@ module PluckMap
 
         def [](value)
           self.class.arel_table[value]
+        end
+
+        def _read_attribute(attr_name)
+          self[attr_name]
         end
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require "rubygems"
 
 require "minitest/reporters/turn_reporter"
-MiniTest::Reporters.use! Minitest::Reporters::TurnReporter.new
+Minitest::Reporters.use! Minitest::Reporters::TurnReporter.new
 
 require "database_cleaner"
 require "pluck_map"


### PR DESCRIPTION
This does remove the appraisals for `<6`. I don’t know that we _have_ to make that call, but if we’re going to make a new `2.0.x` version for these changes, I think it’d be ok to say you need this version if you’re on Rails `6+`